### PR TITLE
Provide option for additional language definition paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Unfortunately, Ghidra provides no easy way to observe the process of transformin
 1. In the UI, click `File > Set Ghidra folder` and select the folder in which you installed Ghidra. Relative to this folder, there should be a file in the following path: `./Ghidra/Features/Decompiler/src/decompile/cpp/decomp_dbg`. If there isn't, follow the instructions at "Obtaining `decomp_dbg`". If you have set this path, it will be saved in a settings file (`settings.ini`) so you don't need to set it every time you open the application.
 1. In the UI, click `File > Load XML file` and select an `.xml` file produced by Ghidra using the "Debug Function Decompilation" option.
 
+If your project uses a custom [language definition](https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Features/Base/src/main/help/help/topics/LanguageProviderPlugin/Languages.htm) from an extension not present in the ghidra installation, you will need to specify the path of a directory that contains that language definition (.ldefs file) using the -s command line option. If not certain about where to find that file, ask the developer of the extension.
+
 ## Obtaining `decomp_dbg`
 First, the `decomp_dbg` executable needs to be built. This only needs to be done once (or whenever the decompiler changes) and can be done using these steps:
 

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import os
 import traceback
 import typing
 import xml.etree.ElementTree
+import argparse
 
 from util import get_decompile_data
 from decomp import Decomp, DecompStep
@@ -35,8 +36,10 @@ class MainWindow(QtWidgets.QMainWindow):
     text_edit: QtWidgets.QTextEdit
     thread_manager: QtCore.QThreadPool
 
-    def __init__(self):
+    def __init__(self, extrapaths = []):
         super().__init__()
+
+        self.extrapaths = extrapaths
 
         self.setWindowTitle("DecompVis")
 
@@ -203,7 +206,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         try:
             initial_pcode, data = get_decompile_data(
-                self.decomp_dbg_path, self.ghidra_dir, self.xml_path, self.xml_func_name
+                self.decomp_dbg_path, self.ghidra_dir, self.xml_path, self.xml_func_name, self.extrapaths
             )
 
             decomp = Decomp(initial_pcode)
@@ -263,9 +266,13 @@ class MainWindow(QtWidgets.QMainWindow):
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--extrapaths', nargs='+', help='Define extra paths to search for language definitions (.ldefs)', required=False, default=[])
+    args = parser.parse_args()
+
     app = QtWidgets.QApplication(sys.argv)
 
-    mw = MainWindow()
+    mw = MainWindow(args.extrapaths)
     mw.show()
 
     exitcodesys = app.exec()

--- a/main.py
+++ b/main.py
@@ -36,10 +36,10 @@ class MainWindow(QtWidgets.QMainWindow):
     text_edit: QtWidgets.QTextEdit
     thread_manager: QtCore.QThreadPool
 
-    def __init__(self, extrapaths = []):
+    def __init__(self, extra_paths = []):
         super().__init__()
 
-        self.extrapaths = extrapaths
+        self.extra_paths = extra_paths
 
         self.setWindowTitle("DecompVis")
 
@@ -206,7 +206,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         try:
             initial_pcode, data = get_decompile_data(
-                self.decomp_dbg_path, self.ghidra_dir, self.xml_path, self.xml_func_name, self.extrapaths
+                self.decomp_dbg_path, self.ghidra_dir, self.xml_path, self.xml_func_name, self.extra_paths
             )
 
             decomp = Decomp(initial_pcode)
@@ -267,12 +267,12 @@ class MainWindow(QtWidgets.QMainWindow):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('-s', '--extrapaths', nargs='+', help='Define extra paths to search for language definitions (.ldefs)', required=False, default=[])
+    parser.add_argument('-s', '--extra-paths', nargs='+', help='Define extra paths to search for language definitions (.ldefs)', required=False, default=[])
     args = parser.parse_args()
 
     app = QtWidgets.QApplication(sys.argv)
 
-    mw = MainWindow(args.extrapaths)
+    mw = MainWindow(args.extra_paths)
     mw.show()
 
     exitcodesys = app.exec()

--- a/util.py
+++ b/util.py
@@ -5,11 +5,14 @@ from dataclasses import dataclass
 import typing
 import traceback
 
-def get_decompile_data(decomp_path: str, ghidra_path: str, xml_path: str, func_name: str) -> tuple[bytes, list[bytes]]:
+def get_decompile_data(decomp_path: str, ghidra_path: str, xml_path: str, func_name: str, extrapaths: list[str]) -> tuple[bytes, list[bytes]]:
     """
     Executes the decompiler on the given xml file and returns the P-CODE diffs
     and initial P-CODE.
     """
+
+    command = decomp_path + ''.join([(' -s ' + extrapath) for extrapath in extrapaths])
+
     # TODO: This converts str to bytes only for later functions (eg. Operation::from_raw)
     # to convert the bytes back to str. Consider just returning str from this
     # function.
@@ -24,7 +27,7 @@ def get_decompile_data(decomp_path: str, ghidra_path: str, xml_path: str, func_n
     )
 
     output = subprocess.run(
-        decomp_path, input=input_commands, env={"SLEIGHHOME": ghidra_path},
+        command.split(' '), input=input_commands, env={"SLEIGHHOME": ghidra_path},
         capture_output=True, check=True, text=True
     ).stdout
 


### PR DESCRIPTION
The extra paths are specified from the command line. Maybe not the cleanest option since the main ghidra path setting in on the UI, but the extra paths are a list so it might require a lot of UI to implement