### PR TITLE
Fix expected "trace break 0" response

### DIFF
--- a/util.py
+++ b/util.py
@@ -137,7 +137,7 @@ def get_decompile_data(decomp_path: str, ghidra_path: str, xml_path: str, func_n
         p.readline()  # b'trace break 0\n'
 
         _break_resp = p.readuntil(b"[decomp]> ", drop=True)
-        if _break_resp != b"OK\n":
+        if _break_resp != b"":
             raise ValueError(f"Unexpected response to 'trace break 0': {_break_resp.decode('utf-8')!r}")
 
         ## Start the decompilation


### PR DESCRIPTION
Hi, first of all thanks for the great tool! 

I'm not sure if I made a mistake when setting something up, but the tool would throw an error on me when trying to load an XML, pointing to an unexpected response for "trace break 0".  Executing the command manually did not return anything for me and checking [IfcTraceBreak](https://github.com/NationalSecurityAgency/ghidra/blob/3d7139e0a8217b49a853cc620f4cd0fdf472d611/Ghidra/Features/Decompiler/src/decompile/cpp/ifacedecomp.cc#L3442-L3458) seems that it does not print anything on success.

Can you repro this issue? If yes, here's a one line fix that just checks if the response is empty instead.